### PR TITLE
Add 2021-05-tx-winter-storm-deaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ An index of all our open-source data, analysis, libraries, tools, and guides.
 
 Date|Description|Repo(s)|Article(s)
 ----|-----------|:--:|:-----:
+`2021-05-26`|Analysis of excess deaths caused by the February 2021 winter storm and power outages in Texas|[:link:](https://buzzfeednews.github.io/2021-05-tx-winter-storm-deaths/)|[:link:](https://www.buzzfeednews.com/article/peteraldhous/texas-winter-storm-power-outage-death-toll)
 `2020-11-11`|Analysis of county-level COVID-19 deaths and presidential voter preference|[:link:](https://buzzfeednews.github.io/2020-11-covid-election/)|[:link:](https://www.buzzfeednews.com/article/peteraldhous/coronavirus-deaths-unemployment-trump-election-results)
 `2020-10-28`|Analysis of 2020's "Electoral College effect" by demographic|[:link:](https://github.com/BuzzFeedNews/2020-10-electoral-college-effect-by-demographic)|[:link:](https://www.buzzfeednews.com/article/johntemplon/the-electoral-college-still-favors-white-voters)
 `2020-06-04`|Analysis of "1033" program transfers since Ferguson|[:link:](https://github.com/BuzzFeedNews/2020-06-leso-1033-transfers-since-ferguson)|[:link:](https://www.buzzfeednews.com/article/johntemplon/police-departments-military-gear-1033-program)


### PR DESCRIPTION
Data and [R](https://www.r-project.org/) code to reproduce the analysis underlying [this May 26, 2021 BuzzFeed News article](https://www.buzzfeednews.com/article/peteraldhous/texas-winter-storm-power-outage-death-toll) on the excess deaths caused by the February 2021 winter storm and power outages in Texas.